### PR TITLE
Drop CakePHP <=3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,6 @@ matrix:
   fast_finish: true
 
   include:
-  - php: 5.6
-    env: DEFAULT=1 CAKE_VERSION='3.1.*' DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test'
-
-  - php: 5.6
-    env: DEFAULT=1 CAKE_VERSION='3.2.*' DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test'
-
-  - php: 5.6
-    env: DEFAULT=1 CAKE_VERSION='3.3.*' DB=mysql db_dsn='mysql://root@0.0.0.0/cakephp_test'
-
   - php: 7.2
     env: PHPCS=1 DEFAULT=0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # ActivityLogger plugin for CakePHP 3.x
 
+<p align="center">
+    <a href="LICENSE.txt" target="_blank">
+        <img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square">
+    </a>
+    <a href="https://travis-ci.org/elstc/cakephp-activity-logger" target="_blank">
+        <img alt="Build Status" src="https://img.shields.io/travis/elstc/cakephp-activity-logger/master.svg?style=flat-square">
+    </a>
+    <a href="https://codecov.io/gh/elstc/cakephp-activity-logger" target="_blank">
+        <img alt="Codecov" src="https://img.shields.io/codecov/c/github/elstc/cakephp-activity-logger.svg?style=flat-square">
+    </a>
+    <a href="https://packagist.org/packages/elstc/cakephp-activity-logger" target="_blank">
+        <img alt="Latest Stable Version" src="https://img.shields.io/packagist/v/elstc/cakephp-activity-logger.svg?style=flat-square">
+    </a>
+</p>
+
 ## Installation
 
 You can install this plugin into your CakePHP application using [composer](http://getcomposer.org).
@@ -10,13 +25,18 @@ The recommended way to install composer packages is:
 composer require elstc/cakephp-activity-logger
 ```
 
-### Load plugin bootstrap
+### Load plugin
 
-in `config/bootstrap.php`
+(CakePHP >= 3.6.0) Load the plugin by adding the following statement in your project's `src/Application.php`:
 
-```(php)
-use Cake\Core\Plugin;
-Plugin::load('Elastic/ActivityLogger', ['bootstrap' => true]);
+```
+$this->addPlugin('Elastic/ActivityLogger');
+```
+
+(CakePHP <= 3.5.x) Load the plugin by adding the following statement in your project's `config/bootstrap.php` file:
+
+```
+Plugin::load('Elastic/ActivityLogger');
 ```
 
 ### Create activity_logs table

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "license": ["MIT"],
     "require": {
         "php": ">=5.6",
+        "ext-pdo": "*",
+        "ext-json": "*",
         "cakephp/cakephp": "^3.4",
         "psr/log": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "type": "cakephp-plugin",
     "license": ["MIT"],
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.1",
+        "php": ">=5.6",
+        "cakephp/cakephp": "^3.4",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.7|^6.0"
+        "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controller/Component/AutoIssuerComponent.php
+++ b/src/Controller/Component/AutoIssuerComponent.php
@@ -56,7 +56,12 @@ class AutoIssuerComponent extends Component
     {
         parent::__construct($registry, $config);
 
-        $this->tableLocator = TableRegistry::locator();
+        if (method_exists(TableRegistry::class, 'getTableLocator')) {
+            $this->tableLocator = TableRegistry::getTableLocator();
+        } else {
+            $this->tableLocator = TableRegistry::locator();
+        }
+
         $this->setInitializedTables($this->getConfig('initializedTables'));
     }
 

--- a/src/Controller/Component/AutoIssuerComponent.php
+++ b/src/Controller/Component/AutoIssuerComponent.php
@@ -3,10 +3,9 @@
 namespace Elastic\ActivityLogger\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\AuthComponent;
+use Cake\Controller\ComponentRegistry;
 use Cake\Event\Event;
-use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorInterface;
@@ -17,7 +16,7 @@ use Cake\Utility\Hash;
 /**
  * AutoIssuer component
  */
-class AutoIssuerComponent extends Component implements EventListenerInterface
+class AutoIssuerComponent extends Component
 {
     /**
      * Default configuration.
@@ -58,7 +57,7 @@ class AutoIssuerComponent extends Component implements EventListenerInterface
         parent::__construct($registry, $config);
 
         $this->tableLocator = TableRegistry::locator();
-        $this->setInitializedTables($this->config('initializedTables'));
+        $this->setInitializedTables($this->getConfig('initializedTables'));
     }
 
     /**
@@ -137,10 +136,10 @@ class AutoIssuerComponent extends Component implements EventListenerInterface
      */
     public function onInitializeModel(Event $event)
     {
-        $table = $event->subject();
+        $table = $event->getSubject();
         /* @var $table Table */
-        if (!array_key_exists($table->registryAlias(), $this->tables)) {
-            $this->tables[$table->registryAlias()] = $table;
+        if (!array_key_exists($table->getRegistryAlias(), $this->tables)) {
+            $this->tables[$table->getRegistryAlias()] = $table;
         }
 
         // ログインユーザーが取得できていればセットする
@@ -188,7 +187,7 @@ class AutoIssuerComponent extends Component implements EventListenerInterface
     private function getIssuerFromUserArray($user)
     {
         $table = $this->getUserModel();
-        $userId = Hash::get((array)$user, $table->primaryKey());
+        $userId = Hash::get((array)$user, $table->getPrimaryKey());
         if ($userId) {
             return $table->get($userId);
         }
@@ -203,6 +202,6 @@ class AutoIssuerComponent extends Component implements EventListenerInterface
      */
     private function getUserModel()
     {
-        return TableRegistry::get($this->config('userModel'));
+        return TableRegistry::get($this->getConfig('userModel'));
     }
 }

--- a/src/Controller/Component/AutoIssuerComponent.php
+++ b/src/Controller/Component/AutoIssuerComponent.php
@@ -3,8 +3,8 @@
 namespace Elastic\ActivityLogger\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Controller\Component\AuthComponent;
 use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Component\AuthComponent;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\ORM\Entity;

--- a/src/Model/Behavior/LoggerBehavior.php
+++ b/src/Model/Behavior/LoggerBehavior.php
@@ -87,7 +87,7 @@ class LoggerBehavior extends Behavior
             $scope = [$this->_table->getRegistryAlias()];
         }
 
-        if ($this->config('systemScope')) {
+        if ($this->getConfig('systemScope')) {
             $namespace = $this->getConfig('systemScope') === true
                 ? Configure::read('App.namespace')
                 : $this->getConfig('systemScope');

--- a/src/Model/Behavior/LoggerBehaviorCompletion.php
+++ b/src/Model/Behavior/LoggerBehaviorCompletion.php
@@ -14,6 +14,8 @@ use Elastic\ActivityLogger\Model\Entity\ActivityLog;
 
 /**
  * LoggerBehaviorのメソッド補完
+ *
+ * @deprecated since 1.2.0, use @mixin annotation
  */
 // @codingStandardsIgnoreStart
 trait LoggerBehaviorCompletion// @codingStandardsIgnoreEnd

--- a/src/Model/Table/ActivityLogsTable.php
+++ b/src/Model/Table/ActivityLogsTable.php
@@ -3,7 +3,7 @@
 namespace Elastic\ActivityLogger\Model\Table;
 
 use Cake\Core\Configure;
-use Cake\Database\Schema\Table as Schema;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -27,18 +27,18 @@ class ActivityLogsTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('activity_logs');
-        $this->displayField('id');
-        $this->primaryKey('id');
+        $this->setTable('activity_logs');
+        $this->setDisplayField('id');
+        $this->getPrimaryKey('id');
     }
 
     /**
      * Add data type
      *
-     * @param Schema $table the table
-     * @return Schema
+     * @param TableSchema $table the table
+     * @return TableSchema
      */
-    protected function _initializeSchema(Schema $table)
+    protected function _initializeSchema(TableSchema $table)
     {
         $schema = parent::_initializeSchema($table);
         $schema->columnType('data', 'json_data');
@@ -179,8 +179,8 @@ class ActivityLogsTable extends Table
         $objectModel = null;
         $objectId = null;
         if ($object && $object instanceof Entity) {
-            $objectTable = TableRegistry::get($object->source());
-            $objectModel = $objectTable->registryAlias();
+            $objectTable = TableRegistry::get($object->getSource());
+            $objectModel = $objectTable->getRegistryAlias();
             $objectId = $this->getScopeId($objectTable, $object);
         }
 
@@ -198,7 +198,7 @@ class ActivityLogsTable extends Table
      */
     public function getScopeId(Table $table, EntityInterface $entity)
     {
-        $primaryKey = $table->primaryKey();
+        $primaryKey = $table->getPrimaryKey();
         if (is_string($primaryKey)) {
             return $entity->get($primaryKey);
         }

--- a/src/Model/Table/ActivityLogsTable.php
+++ b/src/Model/Table/ActivityLogsTable.php
@@ -29,7 +29,7 @@ class ActivityLogsTable extends Table
 
         $this->setTable('activity_logs');
         $this->setDisplayField('id');
-        $this->getPrimaryKey('id');
+        $this->setPrimaryKey('id');
     }
 
     /**
@@ -41,7 +41,11 @@ class ActivityLogsTable extends Table
     protected function _initializeSchema(TableSchema $table)
     {
         $schema = parent::_initializeSchema($table);
-        $schema->columnType('data', 'json_data');
+        if (method_exists($schema, 'setColumnType')) {
+            $schema->setColumnType('data', 'json_data');
+        } else {
+            $schema->columnType('data', 'json_data');
+        }
 
         return $schema;
     }

--- a/tests/TestCase/Model/Behavior/LoggerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LoggerBehaviorTest.php
@@ -251,7 +251,7 @@ class LoggerBehaviorTest extends TestCase
             'user_id' => $user->id,
             'comment' => 'Awesome!',
         ]);
-        $this->Comments->behaviors()->get('Logger')->config('scopeMap', [
+        $this->Comments->behaviors()->get('Logger')->setConfig('scopeMap', [
             'article_id' => 'Elastic/ActivityLogger.Articles',
             'user_id' => 'Elastic/ActivityLogger.Users',
         ]);

--- a/tests/TestCase/Model/Behavior/LoggerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LoggerBehaviorTest.php
@@ -70,12 +70,12 @@ class LoggerBehaviorTest extends TestCase
         $this->assertSame([
             'Elastic/ActivityLogger.Authors' => null,
             '\MyApp' => true,
-        ], $this->Authors->logScope(), 'システムスコープがセットされている');
+        ], $this->Authors->getLogScope(), 'システムスコープがセットされている');
         $this->assertSame([
             'Elastic/ActivityLogger.Authors' => null,
             'Elastic/ActivityLogger.Articles' => null,
             'Elastic/ActivityLogger.Users' => null,
-        ], $this->Comments->logScope(), 'systemScope = false ならばシステムスコープはセットされない');
+        ], $this->Comments->getLogScope(), 'systemScope = false ならばシステムスコープはセットされない');
         $this->markTestIncomplete('Not cover all');
     }
 
@@ -199,6 +199,58 @@ class LoggerBehaviorTest extends TestCase
         ], $this->Articles->logScope(), 'ログのスコープがリセットされている');
     }
 
+    public function testLogScopeSetterGetter()
+    {
+        $this->assertSame([
+            'Elastic/ActivityLogger.Authors' => null,
+            '\MyApp' => true,
+        ], $this->Authors->getLogScope(), 'ログのスコープが取得できる');
+        //
+        $this->assertSame([
+            'Elastic/ActivityLogger.Articles' => null,
+            'Elastic/ActivityLogger.Authors' => null,
+            '\MyApp' => true,
+        ], $this->Articles->getLogScope(), 'ログのスコープが取得できる');
+
+        // セットして取得
+        $author = $this->Authors->get(1);
+        $this->Authors->setLogScope($author);
+        $this->assertSame([
+            'Elastic/ActivityLogger.Authors' => 1,
+            '\MyApp' => true,
+        ], $this->Authors->getLogScope(), 'ログのスコープが更新されている');
+        //
+        $article = $this->Articles->get(2);
+        $this->Articles->setLogScope([$article, $author]);
+        $this->assertSame([
+            'Elastic/ActivityLogger.Articles' => 2,
+            'Elastic/ActivityLogger.Authors' => 1,
+            '\MyApp' => true,
+        ], $this->Articles->getLogScope(), 'ログのスコープが取得できる');
+
+        // スコープの追加
+        $this->Articles->setLogScope($this->Comments->get(3));
+        $this->Articles->setLogScope('Custom');
+        $this->Articles->setLogScope(['Another' => 4, 'Foo' => '005', 'Hoge']);
+        $this->assertSame([
+            'Elastic/ActivityLogger.Articles' => 2,
+            'Elastic/ActivityLogger.Authors' => 1,
+            '\MyApp' => true,
+            'Elastic/ActivityLogger.Comments' => 3,
+            'Custom' => true,
+            'Another' => 4,
+            'Foo' => '005',
+            'Hoge' => true,
+        ], $this->Articles->getLogScope(), 'ログのスコープがセットされている');
+        // スコープのリセット
+        $this->Articles->setLogScope(false);
+        $this->assertSame([
+            'Elastic/ActivityLogger.Articles' => null,
+            'Elastic/ActivityLogger.Authors' => null,
+            '\MyApp' => true,
+        ], $this->Articles->getLogScope(), 'ログのスコープがリセットされている');
+    }
+
     public function testSaveWithScope()
     {
         $author = $this->Authors->newEntity([
@@ -225,7 +277,7 @@ class LoggerBehaviorTest extends TestCase
             'user_id' => $user->id,
             'comment' => 'Awesome!',
         ]);
-        $this->Comments->logScope([$article, $user]);
+        $this->Comments->setLogScope([$article, $user]);
         $this->Comments->save($comment);
 
         $logs = $this->ActivityLogs->find()
@@ -273,7 +325,7 @@ class LoggerBehaviorTest extends TestCase
     public function testSaveWithIssuer()
     {
         $user = $this->Users->get(1);
-        $this->Authors->logIssuer($user);
+        $this->Authors->setLogIssuer($user);
         $author = $this->Authors->newEntity([
             'username' => 'foo',
             'password' => 'bar',
@@ -292,8 +344,8 @@ class LoggerBehaviorTest extends TestCase
             'user_id' => $user->id,
             'comment' => 'Awesome!',
         ]);
-        $this->Comments->logIssuer($user);
-        $this->Comments->logScope($article);
+        $this->Comments->setLogIssuer($user);
+        $this->Comments->setLogScope($article);
         $this->Comments->save($comment);
 
         $logs = $this->ActivityLogs->find()
@@ -412,6 +464,69 @@ class LoggerBehaviorTest extends TestCase
 
         // 別のユーザーが削除
         $this->Articles->logIssuer($this->Authors->get(2))->delete($article);
+
+        $logs = $this->ActivityLogs->find()
+            ->where(['scope_model' => 'Elastic/ActivityLogger.Authors'])
+            ->order(['id' => 'asc'])
+            ->all()
+            ->toArray();
+
+        $this->assertCount(4, $logs);
+        $this->assertSame('mariano が記事 #4「バージョン1.0リリース」を作成しました。', $logs[0]->message);
+        $this->assertSame('mariano が記事 #4「バージョン1.0 stableリリース」を更新しました。', $logs[1]->message);
+        $this->assertSame('記事を更新しています。', $logs[2]->message);
+        $this->assertSame('nate が記事 #4「バージョン1.0 stableリリース」を削除しました。', $logs[3]->message);
+    }
+
+    public function testLogMessageBuilderSetterGetter()
+    {
+        $this->assertNull($this->Articles->getLogMessageBuilder());
+        //
+        $this->Articles->setLogMessageBuilder(function (ActivityLog $log, array $context) {
+            if (!empty($log->message)) {
+                return $log->message;
+            }
+
+            $message = '';
+            $object = $context['object'] ?: null;
+            $issuer = $context['issuer'] ?: null;
+            switch ($log->action) {
+                case ActivityLog::ACTION_CREATE:
+                    $message = sprintf('%3$s が記事 #%1$s「%2$s」を作成しました。', $object->id, $object->title, $issuer->username);
+                    break;
+                case ActivityLog::ACTION_UPDATE:
+                    $message = sprintf('%3$s が記事 #%1$s「%2$s」を更新しました。', $object->id, $object->title, $issuer->username);
+                    break;
+                case ActivityLog::ACTION_DELETE:
+                    $message = sprintf('%3$s が記事 #%1$s「%2$s」を削除しました。', $object->id, $object->title, $issuer->username);
+                    break;
+                default:
+                    break;
+            }
+
+            return $message;
+        });
+
+        // 記事を新規作成
+        $author = $this->Authors->get(1);
+        $article = $this->Articles->newEntity([
+            'title' => 'バージョン1.0リリース',
+            'body' => '新しいバージョン 1.0 をリリースしました。',
+            'author' => $author,
+        ]);
+        $this->Articles->setLogIssuer($author);
+        $this->Articles->save($article);
+
+        // 記事を更新
+        $article->title = 'バージョン1.0 stableリリース';
+        $this->Articles->save($article);
+
+        // 任意のログ
+        $this->Articles->activityLog(LogLevel::NOTICE, '記事を更新しています。');
+
+        // 別のユーザーが削除
+        $this->Articles->setLogIssuer($this->Authors->get(2));
+        $this->Articles->delete($article);
 
         $logs = $this->ActivityLogs->find()
             ->where(['scope_model' => 'Elastic/ActivityLogger.Authors'])

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,4 +40,6 @@ if (class_exists('\Cake\I18n\FrozenTime')) {
 
 Plugin::load('Elastic/ActivityLogger', ['path' => dirname(dirname(__FILE__)) . DS, 'bootstrap' => true]);
 
+error_reporting(E_ALL);
+
 require $here . '/test_models.php';

--- a/tests/test_models.php
+++ b/tests/test_models.php
@@ -66,7 +66,7 @@ namespace Elastic\ActivityLogger\Model\Table {
 
         public function initialize(array $config)
         {
-            $this->entityClass('\Elastic\ActivityLogger\Model\Entity\Author');
+            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Author');
             $this->hasMany('Articles', [
                 'className' => '\Elastic\ActivityLogger\Model\Table\ArticlesTable',
             ]);
@@ -84,7 +84,7 @@ namespace Elastic\ActivityLogger\Model\Table {
 
         public function initialize(array $config)
         {
-            $this->entityClass('\Elastic\ActivityLogger\Model\Entity\User');
+            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\User');
             $this->hasMany('Comments', [
                 'className' => '\Elastic\ActivityLogger\Model\Table\CommentsTable',
             ]);
@@ -103,7 +103,7 @@ namespace Elastic\ActivityLogger\Model\Table {
 
         public function initialize(array $config)
         {
-            $this->entityClass('\Elastic\ActivityLogger\Model\Entity\Article');
+            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Article');
             $this->belongsTo('Author', [
                 'className' => '\Elastic\ActivityLogger\Model\Table\AuthorsTable',
             ]);
@@ -130,7 +130,7 @@ namespace Elastic\ActivityLogger\Model\Table {
 
         public function initialize(array $config)
         {
-            $this->entityClass('\Elastic\ActivityLogger\Model\Entity\Comment');
+            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Comment');
             $this->belongsTo('Article', [
                 'className' => '\Elastic\ActivityLogger\Model\Table\ArticlesTable',
             ]);

--- a/tests/test_models.php
+++ b/tests/test_models.php
@@ -55,20 +55,26 @@ namespace Elastic\ActivityLogger\Model\Entity {
 
 namespace Elastic\ActivityLogger\Model\Table {
 
+    use Cake\ORM\Association\BelongsTo;// @codingStandardsIgnoreLine
+    use Cake\ORM\Association\HasMany;// @codingStandardsIgnoreLine
     use Cake\ORM\Table;// @codingStandardsIgnoreLine
+    use Elastic\ActivityLogger\Model\Behavior\LoggerBehavior;// @codingStandardsIgnoreLine
+    use Elastic\ActivityLogger\Model\Entity\Article;// @codingStandardsIgnoreLine
+    use Elastic\ActivityLogger\Model\Entity\Author;// @codingStandardsIgnoreLine
+    use Elastic\ActivityLogger\Model\Entity\Comment;// @codingStandardsIgnoreLine
+    use Elastic\ActivityLogger\Model\Entity\User;// @codingStandardsIgnoreLine
 
     /**
-     * @param \Cake\ORM\Association\HasMany $Articles
+     * @param ArticlesTable|HasMany $Articles
+     * @mixin LoggerBehavior
      */
     class AuthorsTable extends Table
     {
-        use \Elastic\ActivityLogger\Model\Behavior\LoggerBehaviorCompletion;
-
         public function initialize(array $config)
         {
-            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Author');
+            $this->setEntityClass(Author::class);
             $this->hasMany('Articles', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\ArticlesTable',
+                'className' => ArticlesTable::class,
             ]);
 
             $this->addBehavior('Elastic/ActivityLogger.Logger');
@@ -76,17 +82,16 @@ namespace Elastic\ActivityLogger\Model\Table {
     }
 
     /**
-     * @param \Cake\ORM\Association\HasMany $Comments
+     * @param CommentsTable|HasMany $Comments
+     * @mixin LoggerBehavior
      */
     class UsersTable extends Table
     {
-        use \Elastic\ActivityLogger\Model\Behavior\LoggerBehaviorCompletion;
-
         public function initialize(array $config)
         {
-            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\User');
+            $this->setEntityClass(User::class);
             $this->hasMany('Comments', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\CommentsTable',
+                'className' => CommentsTable::class,
             ]);
 
             $this->addBehavior('Elastic/ActivityLogger.Logger');
@@ -94,21 +99,20 @@ namespace Elastic\ActivityLogger\Model\Table {
     }
 
     /**
-     * @param \Cake\ORM\Association\BelongsTo $Authors
-     * @param \Cake\ORM\Association\HasMany $Comments
+     * @param AuthorsTable|BelongsTo $Authors
+     * @param CommentsTable|HasMany $Comments
+     * @mixin LoggerBehavior
      */
     class ArticlesTable extends Table
     {
-        use \Elastic\ActivityLogger\Model\Behavior\LoggerBehaviorCompletion;
-
         public function initialize(array $config)
         {
-            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Article');
+            $this->setEntityClass(Article::class);
             $this->belongsTo('Author', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\AuthorsTable',
+                'className' => AuthorsTable::class,
             ]);
             $this->hasMany('Comments', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\CommentsTable',
+                'className' => CommentsTable::class,
             ]);
 
             $this->addBehavior('Elastic/ActivityLogger.Logger', [
@@ -121,21 +125,20 @@ namespace Elastic\ActivityLogger\Model\Table {
     }
 
     /**
-     * @param \Cake\ORM\Association\BelongsTo $Articles
-     * @param \Cake\ORM\Association\BelongsTo $Users
+     * @param ArticlesTable|BelongsTo $Articles
+     * @param UsersTable|BelongsTo $Users
+     * @mixin LoggerBehavior
      */
     class CommentsTable extends Table
     {
-        use \Elastic\ActivityLogger\Model\Behavior\LoggerBehaviorCompletion;
-
         public function initialize(array $config)
         {
-            $this->setEntityClass('\Elastic\ActivityLogger\Model\Entity\Comment');
+            $this->setEntityClass(Comment::class);
             $this->belongsTo('Article', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\ArticlesTable',
+                'className' => ArticlesTable::class,
             ]);
             $this->belongsTo('User', [
-                'className' => '\Elastic\ActivityLogger\Model\Table\UsersTable',
+                'className' => UsersTable::class,
             ]);
 
             $this->addBehavior('Elastic/ActivityLogger.Logger', [


### PR DESCRIPTION
- No longer support CakePHP <=3.3
- LoggerBehavior::logScope(), LoggerBehavior::logIssuer(), LoggerBehavior::logMessageBuilder() is deprecated. instead use getLogScope/setLogScope, getLogIssuer/setLogIssuer, getLogMessageBuilder/setLogMessageBuilder.
- LoggerBehaviorCompletion is deprecated. instead use @mixin annotation.